### PR TITLE
Bug845428: Moves ProXR commands into a single sock.send()

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Release Notes
  * Bug 834568: The lifeguard 'free' state has been dropped in favor of the 'ready' state.
    Devices in the ready state may or may not be attached to a request.
  * The lifeguard UI now displays a link to the attached request for a device, if any.
+ * Bug 845428: Bmm now sends ProXR commands in a single sock.send to accommodate the new ProXR firmware (v3.2).  This is backwards compatible with previous firmware versions.
 
 2.0.3
 =====

--- a/mozpool/bmm/relay.py
+++ b/mozpool/bmm/relay.py
@@ -155,9 +155,7 @@ def get_status(relay_board_name, bank, relay, timeout):
     assert(relay >= 1 and relay <= 8)
 
     with connected_socket(relay_board_name, before) as sock:
-        timed_write(sock, START_COMMAND, before)
-        timed_write(sock, READ_RELAY_N_AT_BANK(relay), before)
-        timed_write(sock, chr(bank), before)
+        timed_write(sock, START_COMMAND + READ_RELAY_N_AT_BANK(relay) + chr(bank), before)
         res = timed_read(sock, before)
         return res2status(res)
 
@@ -178,9 +176,7 @@ def set_status(relay_board_name, bank, relay, status, timeout):
 
     with connected_socket(relay_board_name, before) as sock:
         logger.info("set_status(%s) on %s bank %s relay %s initiated" % (status, relay_board_name, bank, relay))
-        timed_write(sock, START_COMMAND, before)
-        timed_write(sock, status2cmd(status, relay), before)
-        timed_write(sock, chr(bank), before)
+        timed_write(sock, START_COMMAND + status2cmd(status, relay) + chr(bank), before)
         res = timed_read(sock, before)
         if res != COMMAND_OK:
             logger.error("Command on %s did not succeed, status: %d" % (relay_board_name, ord(res)))
@@ -207,18 +203,14 @@ def powercycle(relay_board_name, bank, relay, timeout):
         logger.info("power-cycle on %s bank %s relay %s initiated" % (relay_board_name, bank, relay))
         for status in False, True:
             # set the status
-            timed_write(sock, START_COMMAND, before)
-            timed_write(sock, status2cmd(status, relay), before)
-            timed_write(sock, chr(bank), before)
+            timed_write(sock, START_COMMAND + status2cmd(status, relay) + chr(bank), before)
             res = timed_read(sock, before)
             if res != COMMAND_OK:
                 logger.info("Command on %s did not succeed, status: %d" % (relay_board_name, ord(res)))
                 return False
 
             # check the status
-            timed_write(sock, START_COMMAND, before)
-            timed_write(sock, READ_RELAY_N_AT_BANK(relay), before)
-            timed_write(sock, chr(bank), before)
+            timed_write(sock, START_COMMAND + READ_RELAY_N_AT_BANK(relay) + chr(bank), before)
             res = timed_read(sock, before)
             got_status = res2status(res)
             if (not status and got_status) or (status and not got_status):


### PR DESCRIPTION
This will fix bmm to be compatible with the new relay boards being shipped from NCD and is back compatible  with the previous firmware.
