### PR TITLE
Improved selftest

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ Release Notes
 
 NOTE: see `UPGRADING.md` for instructions to upgrade from version to version.
 
+* [Bug 856123](https://bugzilla.mozilla.org/show_bug.cgi?id=856123): New `selftest.py` script and sample config json included for better hardware failure detection
 * [Bug 914347](https://bugzilla.mozilla.org/show_bug.cgi?id=914347): accept event call `failed_self_test` while in `self_test_running`
 
 4.1.2

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Release Notes
 
 NOTE: see `UPGRADING.md` for instructions to upgrade from version to version.
 
+* [Bug 914347](https://bugzilla.mozilla.org/show_bug.cgi?id=914347): accept event call `failed_self_test` while in `self_test_running`
+
 4.1.2
 =====
 

--- a/mozpool/lifeguard/devicemachine.py
+++ b/mozpool/lifeguard/devicemachine.py
@@ -806,6 +806,9 @@ class self_test_running(AcceptBasicPleaseRequests, statemachine.State):
     def on_self_test_ok(self, args):
         self.machine.goto_state(ready)
 
+    def on_failed_self_test(self, args):
+        self.machine.goto_state(failed_self_test)
+
 ####
 # Failure states
 

--- a/scripts/mozpool_test_config.json
+++ b/scripts/mozpool_test_config.json
@@ -1,0 +1,40 @@
+{
+    "config": {
+        "hardware_type": "Panda ES"
+    }, 
+    "test_mmc_blk_dev": {
+        "mmc_device_list": [
+            "mmcblk0", 
+            "mmcblk0p1", 
+            "mmcblk0p2", 
+            "mmcblk0p3", 
+            "mmcblk0p4", 
+            "mmcblk0p5", 
+            "mmcblk0p6"
+        ], 
+        "priority": 1, 
+        "verbose": true
+    }, 
+    "test_mmc_register": {
+        "kernel_sys_mmc_path": "/sys/class/mmc_host/mmc0/mmc0:*", 
+        "priority": 2, 
+        "verbose": true
+    }, 
+    "test_preseed_file_integrity": {
+        "boot_partition": "mmcblk0p1", 
+        "file_hash_dict": {
+            "MLO": "768ba483e7664efc4280c4d5aa2834f26a80d8f5", 
+            "boot.scr": "6261fdd19a45db13e6503c5010e3917dbb13eeed", 
+            "boot.txt": "1c40f7329f46813bdf74f6f7d71a561e2bd48149", 
+            "omap4-panda.dtb": "a91539cc6f656a4b9847bb7cd086c343022aef10", 
+            "u-boot.img": "31f3daf95ff8e59f086ae326ec62a3b0664ef9c4"
+        }, 
+        "priority": 2, 
+        "verbose": true
+    }, 
+    "test_proc_partition_hash": {
+        "file_hash": "bdcdaf582e144be3af7535a2f1d93611f515d0ed", 
+        "priority": 2, 
+        "verbose": true
+    }
+}

--- a/scripts/selftest.py
+++ b/scripts/selftest.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import urllib2
+import os
+import stat
+import sys
+import hashlib
+import subprocess
+import json
+import logging
+import logging.handlers
+import glob
+from socket import gethostname
+
+
+# grab device id
+device_id = gethostname()
+
+
+def parse_cmdline():
+    """
+    Reads /proc/cmdline and parses it for the mozpool IP and the json config url
+    """
+    proc_cmd = open('/proc/cmdline', 'r').read()
+    for kernel_args in proc_cmd.split():
+        if kernel_args.startswith('syslog-server='):
+            mozpool_ip = kernel_args.rpartition('=')[2]
+        elif kernel_args.startswith('selftest-config='):
+            json_url = kernel_args.rpartition('=')[2]
+    return mozpool_ip, json_url
+
+
+def init_logger(syslog_server):
+    """
+    Configure and return the logging facility
+    """
+    local_log_file = '/opt/selftest.log'
+    logger = logging.getLogger('selftest.py')
+    logger.setLevel(logging.DEBUG)
+    fh = logging.FileHandler(local_log_file)
+    fh.setLevel(logging.DEBUG)
+    sys_h = logging.handlers.SysLogHandler(
+        address=(syslog_server, 514),
+        facility=logging.handlers.SysLogHandler.LOG_LOCAL0)
+    sys_h.setLevel(logging.DEBUG)
+    file_formatter = logging.Formatter('%(asctime)s - %(name)s[%(levelname)s]: %(message)s')
+    syslog_formatter = logging.Formatter(device_id + ' %(name)s[%(levelname)s]: %(message)s')
+    fh.setFormatter(file_formatter)
+    sys_h.setFormatter(syslog_formatter)
+    logger.addHandler(fh)
+    logger.addHandler(sys_h)
+    return logger
+
+
+def submit_event(event, mozpool_server):
+    """
+    Submit an event to mozpool http rest API
+    """
+
+    url = 'http://{0}/api/device/{1}/event/{2}/'.format(mozpool_server, device_id, event)
+    urllib2.urlopen(urllib2.Request(url, data=''))
+
+
+def retrieve_json(json_url):
+    """
+    Pull down the json config file and return the string
+    """
+
+    json_string = urllib2.urlopen(urllib2.Request(json_url))
+    return json_string.read()
+
+
+class TestFailureError(Exception):
+    """Generic Test Failure Error"""
+
+
+class TestConfigError(Exception):
+    """Failed to configure test"""
+
+
+class DiagUtils(object):
+
+    def hash_file(self, file_name):
+        """Hash file into sha1 and return digest"""
+        with open(file_name, 'r') as f:
+            sha1_digest = hashlib.sha1(f.read()).hexdigest()
+        f.close()
+        return sha1_digest
+
+
+class MozpoolSelftest(object):
+
+    # These config keys are common to all tests and a hard requirement
+    required_config_keys = ('priority', 'verbose')
+
+    # These should be overridden
+    config = {}
+    # Each test must have a unique name defined
+    testname = 'None'
+    config_priority = 0
+    config_verbose = False
+    # tuple of keys expected to be supplied in the config dict
+    expected_config_keys = ()
+
+    def __init__(self, config_dict):
+        self.config = config_dict
+        self.utils = DiagUtils()
+        self.validate_config()
+        self.logger = logging.getLogger('selftest.py')
+
+    def validate_config(self):
+        for keys in self.expected_config_keys:
+            if keys in self.config:
+                # unpack config into instance vars beginning with 'config_'
+                setattr(self, 'config_' + keys, self.config[keys])
+            else:
+                # required or expected config atrrib not found
+                raise TestConfigError
+
+    def _test_passed(self, log_msg):
+        log_str = '{0}[PASSED] {1}'.format(self.testname, log_msg)
+        self._log(log_str)
+
+    def _test_failed(self, log_msg):
+        log_str = '{0}[FAILED] {1}'.format(self.testname, log_msg)
+        self._log(log_str)
+        raise TestFailureError
+
+    def _test_info(self, log_msg):
+        log_str = '{0}[INFO] {1}'.format(self.testname, log_msg)
+        self._log(log_str)
+
+    def _log(self, log_msg):
+        self.logger.info(log_msg)
+
+    def run_test(self):
+        self._test_info('Starting diagnostic test')
+        self.test()
+        self._test_info('Ending diagnostic test')
+
+    def test(self):
+        raise NotImplementedError
+
+
+class test_mmc_blk_dev(MozpoolSelftest):
+    """
+    This test checks that the mmc driver has created the mmc block device file
+    In some instances, the panda board rom successfully reads the sd card to
+    exec the boot loader but the kernel fails to recognize it
+    """
+
+    testname = 'test_mmc_blk_dev'
+
+    # test specific config attributes
+    config_mmc_device_list = []
+
+    expected_config_keys = MozpoolSelftest.required_config_keys + ('mmc_device_list',)
+
+    def test(self):
+    # attempt to stat the mmc block device with the purpose of
+    # checking the file exists and it is a block device
+        for mmcblkdev in self.config_mmc_device_list:
+            mmcblkdev_path = os.path.join('/dev/', mmcblkdev)
+            try:
+                filemode = os.stat(mmcblkdev_path).st_mode
+            except OSError as e:
+                self._test_failed(mmcblkdev_path + ' - ' + e.strerror)
+            else:
+                # Test for blockdevice mode
+                if stat.S_ISBLK(filemode):
+                    self._test_passed(mmcblkdev_path)
+                else:
+                    self._test_failed(mmcblkdev_path + ' - not a block device')
+
+
+class test_proc_partition_hash(MozpoolSelftest):
+    """
+    Since the preseed partition table is static, we can check it against
+    a known hash of /proc/partitions.
+    """
+
+    testname = 'test_proc_partition_hash'
+
+    # test specific config attributes
+    config_file_hash = ''
+
+    expected_config_keys = MozpoolSelftest.required_config_keys + ('file_hash',)
+
+    def test(self):
+        kernel_proc_partitions = '/proc/partitions'
+        sha1_digest = self.utils.hash_file(kernel_proc_partitions)
+        if sha1_digest == self.config_file_hash:
+            self._test_passed(sha1_digest)
+        else:
+            self._test_failed(sha1_digest + '!=' + self.config_file_hash)
+
+
+class test_mmc_register(MozpoolSelftest):
+    """
+    This test checks for files created when a sdcard is detected and initialized
+    by the kernel.  In furture, we might decide to go deeper in evaluating
+    the contents of the files to check attributes such as size of SD card
+    or minimum hardware revision
+    """
+
+    testname = 'test_mmc_register'
+
+    # test specific config attributes
+    config_kernel_sys_mmc_path = ''
+
+    expected_config_keys = MozpoolSelftest.required_config_keys + ('kernel_sys_mmc_path',)
+
+    def test(self):
+        mmc_card_info = {}
+
+        # Since the mmc0 path contains a dynamiclly generated filename, we
+        # glob and return first element. For pandaboards, only one filename
+        # will ever be generated by the kernel.
+        try:
+            kernel_sys_mmc_path = glob.glob(self.config_kernel_sys_mmc_path)[0]
+        except IndexError:
+            self._test_failed(
+                self.config_kernel_sys_mmc_path + ' no filename match found')
+
+        kernel_mmc_files = ('cid', 'csd', 'date', 'erase_size', 'fwrev',
+                            'hwrev', 'manfid', 'name', 'oemid',
+                            'preferred_erase_size', 'scr', 'serial')
+        for kernel_sys_mmc_file in kernel_mmc_files:
+            try:
+                mmc_file = open(os.path.join(kernel_sys_mmc_path, kernel_sys_mmc_file), 'r')
+            except IOError as e:
+                self._test_failed(kernel_sys_mmc_file + ' not found')
+            else:
+                mmc_card_info[kernel_sys_mmc_file] = mmc_file.read()
+                self._test_passed(kernel_sys_mmc_file + ' : ' + mmc_card_info[kernel_sys_mmc_file])
+
+
+class test_preseed_file_integrity(MozpoolSelftest):
+    """
+    This test compares the known sha1 digests of a list of files on the
+    first (boot) partition of the sdcard.  These files are staticly written
+    to the sdcard before being put into service also known as the preseed
+    image files.  Any discrepancies here are an indication the sdcard has
+    is becoming corrrupt or (more likely) the card is using an obsolete
+    preseed image.
+    """
+
+    testname = 'test_preseed_file_integrity'
+
+    # test specific config attributes
+    config_file_hash_dict = {}
+    config_boot_partition = ''
+
+    expected_config_keys = MozpoolSelftest.required_config_keys + ('file_hash_dict', 'boot_partition')
+
+    def test(self):
+        mount_point = os.path.join('/mnt', self.config_boot_partition)
+        dev_mmcblk = os.path.join('/dev', self.config_boot_partition)
+
+        # create the mount point for the boot partition
+        try:
+            os.mkdir(mount_point)
+        except OSError as e:
+            self._test_failed(mount_point + ' - ' + e.strerror)
+
+        # mount the boot partition
+        self._call_cmd(
+            'mount -o ro -t vfat {0} {1}'.format(dev_mmcblk, mount_point))
+
+        for file_name in self.config_file_hash_dict:
+            try:
+                sha1_digest = self.utils.hash_file(os.path.join(mount_point, file_name))
+            except IOError:
+                self._test_failed(file_name + ' : file not found')
+            else:
+                if sha1_digest == self.config_file_hash_dict[file_name]:
+                    self._test_passed(file_name + ' : ' + sha1_digest)
+                else:
+                    self._test_failed(file_name + ' : ' + sha1_digest + ' != ' + self.config_file_hash_dict[file_name])
+        self._call_cmd('umount {0}'.format(mount_point))
+
+    def _call_cmd(self, cmd):
+        """
+        Generic method for executing system commands.  This takes a
+        command line string and spawns a child process of it within
+        a shell.  It then blocks until completion and finally checks
+        return code.  If a non-zero code is returned, the error is
+        passed to _failed_test
+        """
+        proc = subprocess.Popen(
+            cmd, shell=True, bufsize=-1,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        out, _ = proc.communicate()
+        if proc.returncode != 0:
+            self._test_failed(cmd + ' failed : ' + out)
+
+
+class MozpoolSelftestSuite(object):
+
+    config_hardware_type = None
+    test_dict_by_name = {}
+    test_queue = []
+
+    def __init__(self, json_config=None):
+        self.logger = logging.getLogger('selftest.py')
+        if json_config:
+            self.import_json_config(json_config)
+
+    def import_json_config(self, json_str):
+        """
+        Here we take a json str, unpack it and setup tests
+        based on the config data supplied
+        """
+
+        unpacked_config = json.loads(json_str)
+        config = unpacked_config['config']
+
+        # set test suite attributes from unpacked config dict
+        self.config_hardware_type = config['hardware_type']
+
+        # iterate through the unpacked json looking for keys
+        # which begin with 'test_' and call setup_test to
+        # initialize the test with it's config dict
+        for tests in unpacked_config.keys():
+            if tests.startswith('test_'):
+                self.setup_test(tests, unpacked_config[tests])
+
+    def setup_test(self, testname, config):
+        """
+        This takes a testname str and config dict and attemps to initialize
+        a test class by the same name.
+        """
+
+        module = __import__('__main__')
+
+        try:
+            test_cls = getattr(module, testname)
+            test_obj = test_cls(config)
+            self.test_dict_by_name[testname] = test_obj
+            self.test_queue.append(test_obj)
+            # Sort test obj list by test priority after each insertion
+            self.test_queue.sort(key=lambda test: test.config_priority)
+        except TestConfigError:
+            self.logger.error('Failed to configure test obj [{0}]'.format(testname))
+            raise TestFailureError
+        except AttributeError:
+            self.logger.error('Failed to find test class [{0}]'.format(testname))
+            raise TestFailureError
+
+    def exec_test(self, name):
+        """
+        Executes a single test by name
+        """
+
+        test_obj = self.test_dict_by_name[name]
+        test_obj.run_test()
+
+    def exec_all_tests(self):
+        """
+        Executes all tests in proper order based on there order in test_queue
+        """
+
+        for test_obj in self.test_queue:
+            test_obj.run_test()
+
+
+def main(*args, **kwargs):
+
+    mozpool_ip, json_url = parse_cmdline()
+    # configure and initialize logger
+    logger = init_logger(mozpool_ip)
+    submit_event('self_test_running', mozpool_ip)
+    logger.info('Starting selftest.py')
+
+    # download json config file to a string
+    json_str = retrieve_json(json_url)
+    try:
+        # initialize selftest suite with json config string
+        testsuite = MozpoolSelftestSuite(json_str)
+        # fire off all the tests
+        testsuite.exec_all_tests()
+    except TestFailureError:
+        submit_event('failed_self_test', mozpool_ip)
+        sys.exit(-1)
+
+    submit_event('self_test_ok', mozpool_ip)
+    logger.info('Finished selftest.py')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This includes the change to lifeguard to allow failed_self_test to be called plus the new selftest.py and config json

No code changes to selftest.py and mozpool_test_config.json to what is in production (@mozilla) now.
